### PR TITLE
Generated plan for eventual public packaging & light contrib docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to [project name]
+
+## Overview
+Please note our general guidelines for contributing to NDCLab projects [here](https://ndclab.github.io/wiki/docs/contributing.html).
+
+* [Roadmap](#Roadmap)  
+* [Directory Structure](#Directory-Structure)  
+* [Scripts](#Scripts)
+* [Containers](#Containers)  
+* [Workflow](#Workflow)  
+
+## Roadmap
+Please see the roadmap available on the [README.md](https://github.com/NDCLab/template-tool/blob/main/README.md) file of this repository.
+
+:point_right: Keep the "Roadmap" text above but update the link to the `readme` for your repo. And, of course, delete this note before publishing the contributing file.
+
+## Directory Structure
+:point_right: Update this section as appropriate for your repo, then delete this note before publishing.
+
+```yml
+project-name
+├── run.py
+├── scripts
+|    ├──__init__.py
+├── container
+|    ├──Dockerfile.template 
+|    ├──environment.yml
+|    ├──README.md 
+├── .github 
+```
+
+### Scripts
+The `scripts` directory is the local [package](https://docs.python.org/3/tutorial/modules.html#packages) where Python modules will be written. This ensures that modules are neatly divided according to responsibility, which helps with parallel development and debugging. 
+
+### Container
+To ensure reproducibility of results and software, a default docker file is included with this template repository. The respective [README.md](https://github.com/NDCLab/template-tool/tree/main/container) contains a comprehensive guide on how to get started with containerization (special thanks to [Jonhas](https://github.com/Jonhas))!
+
+A step-by-step guide to getting started also included in the following [video](https://www.youtube.com/watch?v=oO8n3y23b6M). 
+
+## Workflow
+Workflow for both internal and external lab members is outlined on the [NDCLab contributing wiki page](https://ndclab.github.io/wiki/docs/contributing.html). 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,21 +12,13 @@ Please note our general guidelines for contributing to NDCLab projects [here](ht
 ## Roadmap
 Please see the roadmap available on the [README.md](https://github.com/NDCLab/template-tool/blob/main/README.md) file of this repository.
 
-:point_right: Keep the "Roadmap" text above but update the link to the `readme` for your repo. And, of course, delete this note before publishing the contributing file.
-
 ## Directory Structure
-:point_right: Update this section as appropriate for your repo, then delete this note before publishing.
 
 ```yml
 project-name
-├── run.py
-├── scripts
-|    ├──__init__.py
-├── container
-|    ├──Dockerfile.template 
-|    ├──environment.yml
-|    ├──README.md 
-├── .github 
+├── adexi
+├── chexi
+├── texi
 ```
 
 ### Scripts

--- a/README.md
+++ b/README.md
@@ -1,38 +1,37 @@
 # instruments
-surveys, questionnaires, inventories
 
-### ADEXI, TEXI, and CHEXI
-##### ADEXI
-This repo contains:
-* the published English ADEXI
-    * self-report, in .docx and .pdf formats
-    * other-report, in .docx and .pdf formats
-* the translation of the English ADEXI into Spanish for Latin America (esla)
-    * self-report, in .docx and .pdf formats
-    * other-report, in .docx and .pdf formats
-    * a .csv file providing transparency on the translation, editing, back translation, and reconciliation process used to accomplish the translation
+## Project Goal
+A home for all surveys, questionnaires, and inventories used by the NDCLab, with an automatic scoring script.
 
-##### TEXI
-This repo contains:
-* the modified English TEXI
-    * self-report, in .docx and .pdf formats
-    * other-report, in .docx and .pdf formats
-    * redlines of the modifications made by the NDCLab
-* the translation of the modified English TEXI into Spanish for Latin America (esla)
-    * self-report, in .docx and .pdf formats
-    * other-report, in .docx and .pdf formats
-    * a .csv file providing transparency on the translation, editing, back translation, and reconciliation process used to accomplish the translation
-* the translation of the modified English TEXI into Spanish for Latin America (eseu)
-    * self-report, in .docx and .pdf formats
-    * other-report, in .docx and .pdf formats
-    * a .csv file providing transparency on the translation, editing, back translation, and reconciliation process used to accomplish the translation
 
-##### CHEXI
-This repo contains:
-* the published English CHEXI
-    * parent-and-teachers report, in .docx and .pdf formats
-* the translation of the English CHEXI into Spanish for Latin America (esla)
-    * parent-and-teachers report, in .docx and .pdf formats
-    * a .csv file providing transparency on the translation, editing, back translation, and reconciliation process used to accomplish the translation
+## Background & Design
+Each instrument used by the lab exists in the repo as a folder, containing (as applicable):
+* the published instrument (in English and any other languages used for lab research)
+* a REDCap import .zip for the instrument
+* any translations completed by the NDCLab
 
-Please report any issues with the ADEXI, TEXI, or CHEXI translations by posting an issue in this GitHub repository.  The English versions are published [here](https://chexi.se/).
+Additionally, this repo holds the scoring script for all scorable instruments.
+
+
+## Roadmap
+As of July 2021, we are working on the initial release of the scoring script, which will include the instruments used in the three inaugural studies of the NDCLab at FIU: social-context-alpha, missing-link-alpha, and rwe-alpha.
+
+
+## Usage
+Replace this text with a description of how a new user should install and use the tool.
+
+
+## Work in Development
+This `main` branch contains completed releases for this project. For all work-in-progress, please switch over to the `dev` branches.
+
+
+## Contributors to the Scoring Script
+| Name | Role |
+| ---  | ---  |
+| Osmany Pujol | created the original scoring script |
+| Farukh Saidmuratov | collaborated on original script |
+
+Learn more about us [here](www.ndclab.com/people).
+
+## Contributing
+If you are interested in contributing, please read our [CONTRIBUTING.md](CONTRIBUTING.md) file.

--- a/README.md
+++ b/README.md
@@ -10,19 +10,38 @@ Each instrument used by the lab exists in the repo as a folder, containing (as a
 * a REDCap import .zip for the instrument
 * any translations completed by the NDCLab
 
-Additionally, this repo holds the scoring script for all scorable instruments.
+Additionally, this repo holds the scoring script for all scorable instruments. For more information on development and planning, consult [CONTRIBUTING.md](https://github.com/NDCLab/instruments/blob/main/CONTRIBUTING.md).
 
 
 ## Roadmap
-As of July 2021, we are working on the initial release of the scoring script, which will include the instruments used in the three inaugural studies of the NDCLab at FIU: social-context-alpha, missing-link-alpha, and rwe-alpha.
+The following software iterations are planned for development. Each version comes with a list of requirements. Each iteration is subject to change as the project progresses.
 
+### 0.01 
+
+* Scripts to handle automatic scoring of the following surveys:
+  * ADEXI
+  * CHEXI
+  * TEXI
+* Cron jobs on the labs personal HPC to handle manual run scripts on unprocessed data 
+* Generate documentation `README` for usage
+
+### 0.1
+
+* Configure repository for proper packaging
+* Generate comprehensive documentation on usage and functions
+* Generate comprehensive testing suite to ensure stable release
+  * Generate documentation on test-generation in `CONTRIBUTING`
+
+### 1.0 
+
+* Release for pip/conda usage
 
 ## Usage
 Replace this text with a description of how a new user should install and use the tool.
 
 
 ## Work in Development
-This `main` branch contains completed releases for this project. For all work-in-progress, please switch over to the `dev` branches.
+This `main` branch contains completed releases for this project. For all work-in-progress, please switch over to the `dev` branch.
 
 
 ## Contributors to the Scoring Script

--- a/adexi/readme.md
+++ b/adexi/readme.md
@@ -2,7 +2,7 @@
 
 This repo contains:
 
-#### English
+### English
 * self-report
     * .docx format
     * .pdf format, as published on [chexi.se](https://chexi.se/downloads)
@@ -11,7 +11,7 @@ This repo contains:
     * .docx format
     * .pdf format, as published on [chexi.se](https://chexi.se/downloads)
 
-#### Spanish for Latin America (ESLA)
+### Spanish for Latin America (ESLA)
 * self-report
     * .docx format
     * .pdf format
@@ -22,7 +22,7 @@ This repo contains:
 
     | Name | Contribution |
     | :--  | :--  |
-    | Aitana Fischer | performed draft translation |
+    | Aitana Fischer | performed the draft translation |
     | Laura Gallardo | independently edited the draft |
     | Emily Machado | back translated the translation to English |
     | Jessica Alexander | reconciled the forward and back translations |
@@ -30,5 +30,5 @@ This repo contains:
 Please report any issues with the ADEXI translations by posting an issue in this GitHub repository.
 
 
-#### Scoring Script
+### Scoring Script
 The English self-report is included in the repository scoring script.

--- a/adexi/readme.md
+++ b/adexi/readme.md
@@ -1,0 +1,34 @@
+## ADEXI
+
+This repo contains:
+
+#### English
+* self-report
+    * .docx format
+    * .pdf format, as published on [chexi.se](https://chexi.se/downloads)
+    * REDCap import .zip
+* other-report
+    * .docx format
+    * .pdf format, as published on [chexi.se](https://chexi.se/downloads)
+
+#### Spanish for Latin America (ESLA)
+* self-report
+    * .docx format
+    * .pdf format
+* other-report
+    * .docx format
+    * .pdf format
+* a .csv file providing transparency on the translation process used to accomplish the translation of the English ADEXI into Spanish for Latin America, which was performed by members of the NDCLab in 2021:
+
+    | Name | Contribution |
+    | :--  | :--  |
+    | Aitana Fischer | performed draft translation |
+    | Laura Gallardo | independently edited the draft |
+    | Emily Machado | back translated the translation to English |
+    | Jessica Alexander | reconciled the forward and back translations |
+
+Please report any issues with the ADEXI translations by posting an issue in this GitHub repository.
+
+
+#### Scoring Script
+The English self-report is included in the repository scoring script.

--- a/chexi/readme.md
+++ b/chexi/readme.md
@@ -1,0 +1,26 @@
+## CHEXI
+
+This repo contains:
+
+#### English
+* parent-and teachers report
+    * .docx format
+    * .pdf format, as published on [chexi.se](https://chexi.se/downloads)
+
+#### Spanish for Latin America (ESLA)
+* parent-and teachers report
+    * .docx format
+    * .pdf format
+* a .csv file providing transparency on the translation process used to accomplish the translation of the English CHEXI into Spanish for Latin America, which was performed by members of the NDCLab in 2021.
+
+    | Name | Contribution |
+    | :--  | :--  |
+    | Aitana Fischer | performed draft translation |
+    | Laura Gallardo | independently edited the draft |
+    | Emily Machado | back translated the translation to English |
+    | Jessica Alexander | reconciled the forward and back translations |
+
+Please report any issues with the CHEXI translations by posting an issue in this GitHub repository.
+
+#### Scoring Script
+The CHEXI is **not** included in the repository scoring script.

--- a/chexi/readme.md
+++ b/chexi/readme.md
@@ -2,12 +2,12 @@
 
 This repo contains:
 
-#### English
+### English
 * parent-and teachers report
     * .docx format
     * .pdf format, as published on [chexi.se](https://chexi.se/downloads)
 
-#### Spanish for Latin America (ESLA)
+### Spanish for Latin America (ESLA)
 * parent-and teachers report
     * .docx format
     * .pdf format
@@ -15,12 +15,12 @@ This repo contains:
 
     | Name | Contribution |
     | :--  | :--  |
-    | Aitana Fischer | performed draft translation |
+    | Aitana Fischer | performed the draft translation |
     | Laura Gallardo | independently edited the draft |
     | Emily Machado | back translated the translation to English |
     | Jessica Alexander | reconciled the forward and back translations |
 
 Please report any issues with the CHEXI translations by posting an issue in this GitHub repository.
 
-#### Scoring Script
+### Scoring Script
 The CHEXI is **not** included in the repository scoring script.

--- a/texi/readme.md
+++ b/texi/readme.md
@@ -1,0 +1,51 @@
+## TEXI
+
+This repository contains:
+
+#### English
+* the modified English self-report
+    * .docx format
+    * .pdf format
+    * redlines of the modifications made by the NDCLab to the [published version](https://chexi.se/downloads)
+* the modified English other-report
+    * .docx format
+    * .pdf format
+    * redlines of the modifications made by the NDCLab to the [published version](https://chexi.se/downloads)
+
+#### Spanish for Latin America (ESLA)
+* self-report (based on the modified English)
+    * .docx format
+    * .pdf format
+* other-report (based on the modified English)
+    * .docx format
+    * .pdf format
+* a .csv file providing transparency on the translation process used to accomplish the translation of the English TEXI into Spanish for Latin America, which was performed by members of the NDCLab in 2021.
+
+    | Name | Contribution |
+    | :--  | :--  |
+    | Aitana Fischer | performed draft translation |
+    | Laura Gallardo | independently edited the draft |
+    | Emily Machado | back translated the translation to English |
+    | Jessica Alexander | reconciled the forward and back translations |
+
+#### Spanish for Spain (ESEU)
+* self-report (based on the modified English)
+    * .docx format
+    * .pdf format
+* other-report (based on the modified English)
+    * .docx format
+    * .pdf format
+* a .csv file providing transparency on the translation process used to accomplish the translation of the English TEXI into Spanish for Spain, which was performed by members of the NDCLab in 2021.
+
+    | Name | Contribution |
+    | :--  | :--  |
+    | Aitana Fischer | performed draft translation |
+    | Emily Machado | back translated the translation to English |
+    | Jessica Alexander | reconciled the forward and back translations |
+
+*Note regarding modifications:* Several small errors in the [published English TEXI](https://chexi.se/downloads) were identified during the translation process undertaken by the NDCLab. These were corrected prior to translation and notified to the team at the Karolinska Institutet.
+
+Please report any issues with the TEXI translations by posting an issue in this GitHub repository.
+
+#### Scoring Script
+The TEXI is **not** included in the repository scoring script.

--- a/texi/readme.md
+++ b/texi/readme.md
@@ -2,7 +2,7 @@
 
 This repository contains:
 
-#### English
+### English
 * the modified English self-report
     * .docx format
     * .pdf format
@@ -12,7 +12,7 @@ This repository contains:
     * .pdf format
     * redlines of the modifications made by the NDCLab to the [published version](https://chexi.se/downloads)
 
-#### Spanish for Latin America (ESLA)
+### Spanish for Latin America (ESLA)
 * self-report (based on the modified English)
     * .docx format
     * .pdf format
@@ -23,12 +23,12 @@ This repository contains:
 
     | Name | Contribution |
     | :--  | :--  |
-    | Aitana Fischer | performed draft translation |
+    | Aitana Fischer | performed the draft translation |
     | Laura Gallardo | independently edited the draft |
     | Emily Machado | back translated the translation to English |
     | Jessica Alexander | reconciled the forward and back translations |
 
-#### Spanish for Spain (ESEU)
+### Spanish for Spain (ESEU)
 * self-report (based on the modified English)
     * .docx format
     * .pdf format
@@ -39,7 +39,7 @@ This repository contains:
 
     | Name | Contribution |
     | :--  | :--  |
-    | Aitana Fischer | performed draft translation |
+    | Aitana Fischer | performed the draft translation |
     | Emily Machado | back translated the translation to English |
     | Jessica Alexander | reconciled the forward and back translations |
 
@@ -47,5 +47,5 @@ This repository contains:
 
 Please report any issues with the TEXI translations by posting an issue in this GitHub repository.
 
-#### Scoring Script
+### Scoring Script
 The TEXI is **not** included in the repository scoring script.


### PR DESCRIPTION
After a light search for packages to handle project goals, we've come to find that no such Python package is available via open source. We propose completing this repo and creating a front-facing package for other researchers/coders to use for the automatic scoring of various surveys.

This PR includes the following:

- initial roadmap of repo
