### PR TITLE
Correct bmis rev scoring

### DIFF
--- a/scripts/subscore.py
+++ b/scripts/subscore.py
@@ -7,14 +7,14 @@ from score_type import ScoreType
 
 class Subscore:
     """Base subscore class that contains methods for scoring surveys according to parameters.
-    If all params are empty, scores total sum as default. 
+    If all params are empty, scores total sum as default.
 
     Instance Variables
     ----------
-    name:   str 
+    name:   str
             String representing survey name.
     questions:  list() | none
-                Which questions to select for scoring.
+                Which questions to select for scoring (includes forward and rev scored questions).
     sub_name:   str
                 String representing subscore name
     score_type: String | custom_score()
@@ -22,7 +22,7 @@ class Subscore:
     prev_data:  pd.DataFrame() | None
                 Pandas dataframe containing previously generated data
     threshold:  float | list()
-                Float that represents threshold to score row. 1.0 by default, which indicates all 
+                Float that represents threshold to score row. 1.0 by default, which indicates all
                 questions must be answered. Can be a list to represent a threshold range.
                 Ex: [0.82, 1], Greater than 0.83, less than 1
     rev_questions:  list() | None
@@ -32,9 +32,9 @@ class Subscore:
             reverse scoring.
     products:   list() | None
                 List of products to score from "prev_data". "prev_data" must be included to score
-    criteria:   list() | None  
+    criteria:   list() | None
                 list of valid answers. None if any answer is valid
-    
+
     Private Methods
     ----------
     _perc_column(self):
@@ -47,7 +47,7 @@ class Subscore:
 
     _select_questions(self, data):
             Function to select subset of questions on passed data based on self.select_questions.
-            Returns modified dataframe. 
+            Returns modified dataframe.
     _get_unique_sre(self, row):
             Function to get unique sessions, rows, and events, sorted in mentioned order.
             Returns list of labels.
@@ -57,20 +57,20 @@ class Subscore:
             Function to score conditionally using conditional.
     _score_type(self, row):
             Function to score row based on type, conditional, and reverse scoring.
-            Scores mean if self.type is "avg". Scores sum otherwise. 
+            Scores mean if self.type is "avg". Scores sum otherwise.
     _valid_thresh(self, perc):
             Function to check if percentage of row complete is valid using self.threshold
 
     Public Methods
     ----------
     perc_complete(self, row):
-            Function to get percentage of complete questions for selected questions on passed row. 
+            Function to get percentage of complete questions for selected questions on passed row.
             Returns float representing percentage.
     score(self, data):
-            Function to get score and percenatage complete. Returns dataframe of indices and column of floats. 
+            Function to get score and percenatage complete. Returns dataframe of indices and column of floats.
 
     gen_data(self, data, prev_products=None):
-            Function to get score, percentage complete as dataframe for subscore. Optionally 
+            Function to get score, percentage complete as dataframe for subscore. Optionally
             include previous subscores.
     """
     SCORED = "scrd"
@@ -92,7 +92,7 @@ class Subscore:
         self.products = products
         self.conditional = conditional
         self.criteria = criteria
-        
+
     def _perc_column(self, label):
         return self.name + self.DELIM + self.PERCENT + self.sub_name[0].capitalize() + self.sub_name[1:] \
             + self.DELIM + label
@@ -119,7 +119,7 @@ class Subscore:
         select_data = data.filter(items=select_columns)
 
         return select_data
-    
+
     def _select_products(self, data):
         # If there is no selection, return empty dataframe
         if self.products is None:
@@ -149,7 +149,7 @@ class Subscore:
         # Filter unique sessions, runs, and events
         unique_vals = set([re.search(sre_reg, ind).group(0) for ind in ind_names])
         return unique_vals
-    
+
     def _reverse_score(self, data):
         # If there are no reverse questions specified, return data
         if self.rev_questions is None:
@@ -164,16 +164,16 @@ class Subscore:
             select_columns += list(
                 handle.filter(regex=rf"{self.name}{self.DELIM}i{num}{self.DELIM}").columns
             )
-        
+
         # reverse each questions score according to max
         for rev_q in select_columns:
             handle[rev_q] = handle[rev_q].map(lambda s: self.max - int(s) if not pd.isna(s) else s)
-        
+
         return handle
 
     def _score_type(self, row):
         # filter series according to criteria, if applicable
-        if self.criteria is not None:   
+        if self.criteria is not None:
             row.where(row.isin(self.criteria), inplace=True)
 
         # attempt to parse custom score
@@ -183,7 +183,7 @@ class Subscore:
 
         # Score according score_type
         if ScoreType[self.score_type] == ScoreType.avg:
-            return row.mean()  
+            return row.mean()
         elif ScoreType[self.score_type] == ScoreType.sum:
             return row.sum()
         elif ScoreType[self.score_type] == ScoreType.diff:
@@ -196,7 +196,7 @@ class Subscore:
             return row.min()
         elif ScoreType[self.score_type] == ScoreType.max:
             return row.max()
-    
+
     def _valid_thresh(self, perc):
         if isinstance(self.threshold, (int, float)):
             return perc >= self.threshold
@@ -219,7 +219,7 @@ class Subscore:
 
         # Select product columns if available
         append_prod = self._select_products(prev_products)
-        
+
         data = self._reverse_score(data)
         data = pd.concat([data, append_prod], axis=1)
 

--- a/scripts/surveys.json
+++ b/scripts/surveys.json
@@ -164,25 +164,25 @@
     },
     "bmis": {
         "Val": {
-            "questions": [1, 2, 5, 6, 11, 13, 14, 16],
+            "questions": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
             "rev_questions": [3, 4, 7, 8, 9, 10, 12, 15],
             "max": 4,
             "score_type": "sum"
         },
         "Aro": {
-            "questions": [1, 3, 5, 7, 8, 11, 12, 14, 15, 16],
+            "questions": [1, 3, 4, 5, 7, 8, 11, 12, 13, 14, 15, 16],
             "rev_questions": [4, 13],
             "max": 4,
             "score_type": "sum"
         },
         "Tird": {
-            "questions": [1, 5, 11, 14, 16],
+            "questions": [1, 4, 5, 9, 11, 14, 16],
             "rev_questions": [4, 9],
             "max": 4,
             "score_type": "sum"
         },
         "Rlx": {
-            "questions": [3, 7, 8, 12, 15],
+            "questions": [3, 7, 8, 12, 13, 15],
             "rev_questions": [13],
             "max": 4,
             "score_type": "sum"


### PR DESCRIPTION
@blope118 I found an error in my previous work when I went to test.  I had not realized that the questions should include all (forward and reverse scored) and then the reverse-scored items were also included in the separate list for reverse items.  I have corrected, as well as added a note to the comments for posterity.  Would you please verify and, if it looks good, merge and re-output the BMIS?  Thank you!