### PR TITLE
Remove comma raising error line 205

### DIFF
--- a/scripts/surveys.json
+++ b/scripts/surveys.json
@@ -202,7 +202,7 @@
         },
         "total":{
             "questions":[5, 6],
-            "products": ["Slp", "Sd", "Hse"],
+            "products": ["Slp", "Sd", "Hse"]
         }
     },
     "covid": {


### PR DESCRIPTION
Removed comma that raised:
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 206 column 9
error, essentially a comma that wasn't supposed to be there per JSON format rules