### PR TITLE
Update gitignore for HPC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ Thumbs.db
 
 # Metadata
 __pycache__/
+
+# HPC
+*.out
+hpc/process.sub
+*.simg


### PR DESCRIPTION
@blope811 

I added three items to the .gitignore file so that these elements can live on the HPC without trying to mirror back to the GitHub remote:
1. Any .out file from a Slurm job.
2. The simple "process.sub" file that allows us to manually run instruments on the HPC.  Users need to modify the input/output paths, but these aren't really "committable" changes.
3. The Singularity image, which is too large to mirror back to the GH remote.

Please review! 🙏 