### PR TITLE
Dev bugfix partial qs partial products true perc multiple sr eperc

### DIFF
--- a/scripts/subscore.py
+++ b/scripts/subscore.py
@@ -265,6 +265,9 @@ class Subscore:
             product = product[0].capitalize() + product[1:] + self.DELIM
             combined_data = pd.concat([combined_data, prev_products.filter(regex=rf"{product}")], axis=1)
 
+        if combined_data.empty:
+            return combined_data
+        
         unique_cols = []
         unique_cols.append(self._perc_column(sre))
         unique_cols.append(self._scored_column(sre))

--- a/scripts/subscore.py
+++ b/scripts/subscore.py
@@ -200,7 +200,7 @@ class Subscore:
 
     def perc_complete(self, row):
         # Get total questions: all questions if no selection, else length of selection
-        total_quest = row.shape[0]
+        total_quest = len(self.questions)
         # Get total answered questions
         answered = row.count()
 

--- a/scripts/subscore.py
+++ b/scripts/subscore.py
@@ -233,6 +233,8 @@ class Subscore:
         # Filter based on selected questions
         data = self._select_questions(data)
         data = self._reverse_score(data)
+        if data.empty:
+            return data
         unique_cols = []
         unique_cols.append(self._perc_column(sre))
         unique_cols.append(self._scored_column(sre))

--- a/scripts/survey.py
+++ b/scripts/survey.py
@@ -170,7 +170,7 @@ class Survey:
                             single_score = sub_obj.gen_data(ver_surv, sre, ver_surv_data.filter(regex=rf"{sre}$"))
                             ver_scores = pd.concat([ver_scores, single_score], axis=1)
                         else:
-                            single_score = sub_obj.gen_data_for_products(ver_surv, sre, ver_surv_data.filter(regex=rf"{sre}$"), ver_scores)
+                            single_score = sub_obj.gen_data_for_products(ver_surv, sre, ver_surv_data.filter(regex=rf"{sre}$"), ver_scores.filter(regex=rf"{sre}$"))
                             if sub_obj.hide != None:
                                 if sub_obj.hide == True:
                                     for product in sub_obj.products:


### PR DESCRIPTION
This PR addresses that last couple bugs found while testing the scripts.

- Allowing the user to completely leave out questions in input data. 
- Fixes a problem that occurred when calculating the percentage of questions answered. In short, before, when calculating the percentage the denominator was taken from row.shape[0] which basically returns the number of questions present in data which does not account for when questions are left out. Now the denominator is based on number of questions in surveys.json
- Fixes a problem where the data for surveys with products with different sres were being combined instead of having separate data to work with for each sre. This affected the calculation of percentage for surveys with products. Now, data is filtered for each sre.